### PR TITLE
brighten gitsigns current line blame

### DIFF
--- a/lua/inkline/colors/init.lua
+++ b/lua/inkline/colors/init.lua
@@ -6,6 +6,7 @@ M.base_colors = {
   bg           = "#000000",
   bg_alt       = "#1e2124",
   bg_highlight = "#3c4048",
+  dark_grey_5  = "#6b6f78", -- slightly lighter than default NvimDarkGrey4
   black        = "#000000",
   blue         = "#0000FF",
   dark_blue    = "#00008B",

--- a/lua/inkline/groups/init.lua
+++ b/lua/inkline/groups/init.lua
@@ -44,6 +44,9 @@ function M.setup(colors, opts)
     -- Treesitter
     DiagnosticUnnecessary = { fg = colors.grey, italic = true },
 
+    -- GitSigns
+    GitSignsCurrentLineBlame = { fg = colors.dark_grey_5 }
+
     -- ["@variable.member.lua"] = { fg = colors.light_blue },
 
     -- LSP


### PR DESCRIPTION
`GitSignsCurrentLineBlame` links to NonText, which is currently using the Neovim default NvimDarkGrey4, so I added a `dark_grey_5` that is slightly lighter and set current line blame to use that